### PR TITLE
fix latency measurement request arguments

### DIFF
--- a/NTM_Transport/script.js
+++ b/NTM_Transport/script.js
@@ -247,7 +247,7 @@ function configureMaxInlets()
 
 function requestJackTripLatencyMeasurement()
 {
-    socket.emit(REQUEST_START_LATENCY_MEASUREMENT_KEY, (CLIENT_ID));
+    socket.emit(REQUEST_START_LATENCY_MEASUREMENT_KEY, CLIENT_ID);
 };
 
 function startLatencyMeasurement()
@@ -257,7 +257,7 @@ function startLatencyMeasurement()
 
 function requestEndJackTripLatencyMeasurement()
 {
-    socket.emit(REQUEST_END_LATENCY_MEASUREMENT_KEY, (CLIENT_ID));
+    socket.emit(REQUEST_END_LATENCY_MEASUREMENT_KEY, CLIENT_ID);
 };
 
 function updateLatencyMeasurementStatus(status)

--- a/NTM_Transport/script.js
+++ b/NTM_Transport/script.js
@@ -236,7 +236,7 @@ function configureMaxInlets()
 
     window.max.bindInlet("request_jacktrip_latency_measurement", () =>
     {
-        requestJackTripLatencyMeasurement();
+        requestStartJackTripLatencyMeasurement();
     });
 
     window.max.bindInlet("request_end_jacktrip_latency_measurement", () =>
@@ -245,7 +245,7 @@ function configureMaxInlets()
     });
 }
 
-function requestJackTripLatencyMeasurement()
+function requestStartJackTripLatencyMeasurement()
 {
     socket.emit(REQUEST_START_LATENCY_MEASUREMENT_KEY, CLIENT_ID);
 };


### PR DESCRIPTION
- remove parentheses from `CLIENT_ID` arguments to jacktrip latency measurement requests